### PR TITLE
fix migration generator to ensure distinct version numbers

### DIFF
--- a/lib/generators/has_friendship/has_friendship_generator.rb
+++ b/lib/generators/has_friendship/has_friendship_generator.rb
@@ -9,7 +9,10 @@ class HasFriendshipGenerator < Rails::Generators::Base
   end
 
   def self.next_migration_number(path)
-    Time.now.utc.strftime("%Y%m%d%H%M%S")
+    next_num = Time.now.utc.strftime("%Y%m%d%H%M%S").to_i
+    current_num = current_migration_number(path)
+    next_num += (current_num - next_num + 1) if current_num >= next_num
+    next_num.to_s
   end
 
   def create_migration_file


### PR DESCRIPTION
The addition of the add_blocker_id_to_friendships functionality meant that the migration generator now generates 2 migrations. The method to generate each template is fast enough that the 2 calls might happen within the same second, causing their version numbers to be the same. I thought of adding a sleep(1) in between the calls, but that seems kind of lame.  Instead the code I changed ensures that each call to migration_template generates a name that has a unique version number.  It works even if more migrations are added later.