### PR TITLE
add_migration_tests

### DIFF
--- a/spec/has_friendship/generator_spec.rb
+++ b/spec/has_friendship/generator_spec.rb
@@ -15,6 +15,17 @@ describe HasFriendshipGenerator, type: :generator do
     FileUtils.rm_r Dir.glob('spec/tmp/*') # Clean up 'tmp/' after test
   end
 
+  describe "generated migrations" do
+    it "should have a unique version number" do
+      unique_migration_nums = []
+      migration_files = Dir.glob('spec/tmp/db/migrate/*').each do |file|
+        migration_num = File.basename(file).split("_").first.to_i
+        unique_migration_nums << migration_num unless unique_migration_nums.include? migration_num
+      end
+      expect(unique_migration_nums.count).to eq(migration_files.count)
+    end
+  end
+
   specify {
     expect(destination_root).to have_structure {
       directory "db" do


### PR DESCRIPTION
I created a test that shows that the migration_generator is generating migrations with unique version numbers.

If you change the next_migration_number method back to how it was before we changed it, you can see that the test fails. If you then change the main line to be next_num = current_num + 1 if current_num == next_num (like we had wondered about) you can see that the test passes, unless you go in and add another migration. Then it fails.  

With the way the next_migration_number is currently, the test passes regardless of how many migrations you have.