### PR TITLE
Restore friendship function

### DIFF
--- a/lib/has_friendship/friendable.rb
+++ b/lib/has_friendship/friendable.rb
@@ -51,7 +51,7 @@ module HasFriendship
 
       def accept_request(friend)
         on_relation_with(friend) do |one, other|
-          HasFriendship::Friendship.find_unblocked_friendship(one, other).accept!
+          HasFriendship::Friendship.find_unblocked_friendship(one, other).update(status: 2)
         end
       end
 
@@ -65,7 +65,7 @@ module HasFriendship
 
       def block_friend(friend)
         on_relation_with(friend) do |one, other|
-          HasFriendship::Friendship.find_unblocked_friendship(one, other).block!
+          HasFriendship::Friendship.find_unblocked_friendship(one, other).update(status: 3)
         end
       end
 


### PR DESCRIPTION
I restored the accepting function to the gem, I'm not too sure if I did
it the intended way with the 'stateful_enum' gem, but it'll allow new
users to use the gem while the true fix is searched for.