### PR TITLE
Allow Rails 5.0.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2 (2016/5/31)
+
+* Accept Rails 5.0.x as a dependency
+
 ## 1.0.1 (2016/5/14)
 
 * Fix missing methods issue ([#28](https://github.com/sungwoncho/has_friendship/pull/28)) [@f-anthonioz](https://github.com/f-anthonioz)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    has_friendship (1.0.1)
-      rails (~> 4.0)
+    has_friendship (1.0.2)
+      rails (>= 4.0.0, < 5.1.0)
       stateful_enum
 
 GEM
@@ -47,7 +47,7 @@ GEM
     builder (3.2.2)
     byebug (8.2.1)
     coderay (1.1.0)
-    concurrent-ruby (1.0.1)
+    concurrent-ruby (1.0.2)
     coveralls (0.8.10)
       json (~> 1.8)
       rest-client (>= 1.6.8, < 2)

--- a/has_friendship.gemspec
+++ b/has_friendship.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
 
-  s.add_dependency "rails", "~> 4.0"
+  s.add_dependency "rails", ['>= 4.0.0', '< 5.1.0']
   s.add_dependency "stateful_enum"
 
   s.add_development_dependency "sqlite3"

--- a/lib/has_friendship/version.rb
+++ b/lib/has_friendship/version.rb
@@ -1,3 +1,3 @@
 module HasFriendship
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end


### PR DESCRIPTION
This change adds support for Rails 5.0.x. I have been unable to find and breaking changes in my testing.