### PR TITLE
Fix blocker_id to friendable's id

### DIFF
--- a/lib/has_friendship/friendable.rb
+++ b/lib/has_friendship/friendable.rb
@@ -66,7 +66,9 @@ module HasFriendship
 
       def block_friend(friend)
         on_relation_with(friend) do |one, other|
-          HasFriendship::Friendship.find_unblocked_friendship(one, other).block!
+          friendship = HasFriendship::Friendship.find_unblocked_friendship(one, other)
+          friendship.blocker_id = self.id
+          friendship.block!
         end
       end
 

--- a/lib/has_friendship/friendship.rb
+++ b/lib/has_friendship/friendship.rb
@@ -7,10 +7,6 @@ module HasFriendship
       end
 
       event :block do
-        before do
-          self.blocker_id = self.friendable.id
-        end
-
         transition all - [:blocked] => :blocked
       end
     end

--- a/spec/has_friendship/friendable_spec.rb
+++ b/spec/has_friendship/friendable_spec.rb
@@ -214,6 +214,7 @@ describe User, focus: true do
           create_friendship(user, friend)
           user.block_friend(friend)
           expect(find_friendship_record(user, friend).blocker_id).to eq user.id
+          expect(find_friendship_record(friend, user).blocker_id).to eq user.id
         end
       end
     end


### PR DESCRIPTION
When friendship is blocked by user, the blocker_id  of each friendship is assigned by user’s id and friend’s id. And two complementary friendships have different blocker_id.
The blocker_ids should be assigned to the actor.
