### PR TITLE
Create unique index migration

### DIFF
--- a/db/migrate/4_add_unique_index_to_friendships.rb
+++ b/db/migrate/4_add_unique_index_to_friendships.rb
@@ -8,7 +8,7 @@ AddUniqueIndexToFriendships.class_eval do
   disable_ddl_transaction!
 
   def self.up
-    add_index :friendships, [:friendable_id, :friend_id], unique: true, algorithm: :concurrently
+    add_index :friendships, [:friendable_id, :friend_id], unique: true, algorithm: :concurrently unless index_exists? (:friendable_id, :friend_id)
   end
 
   def self.down

--- a/db/migrate/4_add_unique_index_to_friendships.rb
+++ b/db/migrate/4_add_unique_index_to_friendships.rb
@@ -1,0 +1,17 @@
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddUniqueIndexToFriendships < ActiveRecord::Migration[4.2]; end
+else
+  class AddUniqueIndexToFriendships < ActiveRecord::Migration; end
+end
+
+AddUniqueIndexToFriendships.class_eval do
+  disable_ddl_transaction!
+
+  def self.up
+    add_index :friendships, [:friendable_id, :friend_id], unique: true, algorithm: :concurrently
+  end
+
+  def self.down
+    remove_index :friendships, [:friendable_id, :friend_id]
+  end
+end


### PR DESCRIPTION
Adds concurrently unique index between friendable_id and friend_id to prevent duplicate friendships.