### PR TITLE
Add support for rails 6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 cache: bundler
 
 rvm:
+  - 2.7
   - 2.6
   - 2.5
   - 2.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,9 +2,9 @@ PATH
   remote: .
   specs:
     has_friendship (1.1.8)
-      activemodel (>= 4.2.0, < 6.1)
-      activerecord (>= 4.2.0, < 6.1)
-      activesupport (>= 4.2.0, < 6.1)
+      activemodel (>= 4.2.0, < 6.2)
+      activerecord (>= 4.2.0, < 6.2)
+      activesupport (>= 4.2.0, < 6.2)
       stateful_enum
 
 GEM
@@ -38,7 +38,7 @@ GEM
     builder (3.2.3)
     byebug (10.0.2)
     coderay (1.1.2)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.7)
     coveralls (0.8.21)
       json (>= 1.8, < 3)
       simplecov (~> 0.14.1)
@@ -69,7 +69,7 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
-    i18n (1.0.1)
+    i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
     listen (3.1.5)
@@ -82,7 +82,7 @@ GEM
     lumberjack (1.0.13)
     method_source (0.9.0)
     mini_portile2 (2.4.0)
-    minitest (5.11.3)
+    minitest (5.14.2)
     nenv (0.3.0)
     nokogiri (1.10.5)
       mini_portile2 (~> 2.4.0)
@@ -135,12 +135,12 @@ GEM
     rspec-support (3.7.1)
     ruby_dep (1.5.0)
     shellany (0.0.1)
-    shoulda (3.5.0)
-      shoulda-context (~> 1.0, >= 1.0.1)
-      shoulda-matchers (>= 1.4.1, < 3.0)
-    shoulda-context (1.2.2)
-    shoulda-matchers (2.8.0)
-      activesupport (>= 3.0.0)
+    shoulda (4.0.0)
+      shoulda-context (~> 2.0)
+      shoulda-matchers (~> 4.0)
+    shoulda-context (2.0.0)
+    shoulda-matchers (4.4.1)
+      activesupport (>= 4.2.0)
     simplecov (0.14.1)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -154,7 +154,7 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.6)
     tins (1.16.3)
-    tzinfo (1.2.5)
+    tzinfo (1.2.8)
       thread_safe (~> 0.1)
     tzinfo-data (1.2018.5)
       tzinfo (>= 1.0.0)
@@ -175,4 +175,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/has_friendship.gemspec
+++ b/has_friendship.gemspec
@@ -1,4 +1,4 @@
-RAILS_VERSIONS = ['>= 4.2.0', '< 6.1'].freeze
+RAILS_VERSIONS = ['>= 4.2.0', '< 6.2'].freeze
 
 $:.push File.expand_path("../lib", __FILE__)
 

--- a/spec/has_friendship/friendable_spec.rb
+++ b/spec/has_friendship/friendable_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe User do
+describe User, type: :model do
   let(:user) { User.create(name: 'Jessie') }
   let(:friend) { User.create(name: 'Heisenberg') }
 

--- a/spec/has_friendship/friendship_spec.rb
+++ b/spec/has_friendship/friendship_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe HasFriendship::Friendship do
+describe HasFriendship::Friendship, type: :model do
 
   let(:user){ User.create(name: "Jessie") }
   let(:friend){ User.create(name: "Heisenberg") }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -54,5 +54,12 @@ RSpec.configure do |config|
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
 
+  Shoulda::Matchers.configure do |config|
+    config.integrate do |with|
+      with.test_framework :rspec
+      with.library :rails
+    end
+  end
+
   config.include FriendshipMacros
 end


### PR DESCRIPTION
This relax the rails dependency to allow rails 6.1.

Travis has also been updated to run on ruby 2.7.