### PR TITLE
Polymorphic support

### DIFF
--- a/db/migrate/5_add_unique_index_to_friendable_type.rb
+++ b/db/migrate/5_add_unique_index_to_friendable_type.rb
@@ -1,0 +1,46 @@
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddUniqueIndexToFriendableType < ActiveRecord::Migration[4.2]; end
+else
+  class AddUniqueIndexToFriendableType < ActiveRecord::Migration; end
+end
+
+AddUniqueIndexToFriendableType.class_eval do
+  disable_ddl_transaction!
+
+  def self.up
+    return if index_exists?(:friendships, [:friendable_type, :friendable_id, :friend_id])
+
+    options = { unique: true, name: 'unique_friendships_index' }
+
+    adapter_name = connection.adapter_name.downcase
+    if adapter_name.include?('mysql') || adapter_name.include?('postgres')
+        adapter_name.include?('postgis')
+      # These are the only DB adapters that support an index algorithm.
+      options[:algorithm] = :concurrently
+    end
+
+    add_index :friendships,
+      [:friendable_type, :friendable_id, :friend_id],
+      **options
+
+    remove_index :friendships, name: :index_friendships_on_friendable_id_and_friend_id
+  end
+
+  def self.down
+    return unless index_exists?(:friendships, [:friendable_type, :friendable_id, :friend_id])
+
+    options = { unique: true }
+
+    adapter_name = connection.adapter_name.downcase
+    if adapter_name.include?('mysql') || adapter_name.include?('postgres')
+        adapter_name.include?('postgis')
+      # These are the only DB adapters that support an index algorithm.
+      options[:algorithm] = :concurrently
+    end
+
+    add_index :friendships, [:friendable_id, :friend_id], **options
+
+    remove_index :friendships, name: :unique_friendships_index
+
+  end
+end

--- a/lib/has_friendship/friendship.rb
+++ b/lib/has_friendship/friendship.rb
@@ -5,7 +5,7 @@ module HasFriendship
     validate :satisfy_custom_conditions
 
     after_create do |record|
-      friend.on_friendship_created(record)
+      friend.try(:on_friendship_created, record)
     end
 
     after_destroy do |record|

--- a/spec/has_friendship/feature_spec.rb
+++ b/spec/has_friendship/feature_spec.rb
@@ -3,29 +3,61 @@ require 'rails_helper'
 # Might not be needed
 describe "HasFriendship API" do
 
-  let(:user){ User.create(name: "Jessie") }
-  let(:friend){ User.create(name: "Heisenberg") }
+  let(:user){ User.create(name: "Jessie", id: 100) }
+  let(:friend){ User.create(name: "Heisenberg", id: 101) }
 
 	describe "Friend request" do
+
     context "when sent" do
+      before { user.friend_request(friend) }
+
       it "should create pending_friends association" do
-        user.friend_request(friend)
-        expect(user.pending_friends).to include friend
+        expect(user.pending_friends).to include(friend)
       end
 
       it "should create requested_friends association" do
-        user.friend_request(friend)
-        expect(friend.requested_friends).to include user
+        expect(friend.requested_friends).to include(user)
       end
     end
 
-    context "when accepted" do
+    context "when sent and accepted" do
+      before { user.friend_request(friend) }
+      before { friend.accept_request(user) }
+
       it "should create friends association" do
-        user.friend_request(friend)
-        friend.accept_request(user)
-        expect(user.friends).to include friend
-        expect(friend.friends).to include user
+        expect(user.friends).to include(friend)
+        expect(friend.friends).to include(user)
+      end
+    end
+
+    describe "When Friendships is a polymorphic relation" do
+      let(:tom){ Pet.create(name: "Tom", id: 100) }
+      let(:jerry){ Pet.create(name: "Jerry", id: 101) }
+
+      before do
+        tom.friend_request(jerry)
+        jerry.accept_request(tom)
+      end
+
+      context "when different friendable_type is added to the table" do
+        it "creates association using that friendable_type" do
+          expect(tom.friends).to include(jerry)
+          expect(jerry.friends).to include(tom)
+          expect(jerry.friendships.last.friendable_type).to eq(tom.class.to_s)
+        end
+      end
+
+      context "when other friendships records use the same IDs for a different table" do
+        before do
+          user.friend_request(friend)
+          friend.accept_request(user)
+        end
+
+        it "supports all the different friendable_type records" do
+          expect(HasFriendship::Friendship.count).to eq(4)
+        end
       end
     end
   end
+
 end

--- a/spec/internal/app/models/pet.rb
+++ b/spec/internal/app/models/pet.rb
@@ -1,0 +1,3 @@
+class Pet < ActiveRecord::Base
+  has_friendship
+end

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -11,16 +11,21 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 4) do
-
   create_table "friendships", force: :cascade do |t|
     t.string "friendable_type"
     t.integer "friendable_id"
     t.integer "friend_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
     t.integer "blocker_id"
     t.integer "status"
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index ["friendable_id", "friend_id"], name: "index_friendships_on_friendable_id_and_friend_id", unique: true
+  end
+
+  create_table "pets", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "name"
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -10,16 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 4) do
+ActiveRecord::Schema.define(version: 5) do
   create_table "friendships", force: :cascade do |t|
-    t.string "friendable_type"
-    t.integer "friendable_id"
-    t.integer "friend_id"
     t.integer "blocker_id"
-    t.integer "status"
     t.datetime "created_at"
+    t.integer "friend_id"
+    t.integer "friendable_id"
+    t.string "friendable_type"
+    t.integer "status"
     t.datetime "updated_at"
-    t.index ["friendable_id", "friend_id"], name: "index_friendships_on_friendable_id_and_friend_id", unique: true
+    t.index ["friendable_type", "friendable_id", "friend_id"], name: "unique_friendships_index", unique: true
   end
 
   create_table "pets", force: :cascade do |t|
@@ -29,8 +29,8 @@ ActiveRecord::Schema.define(version: 4) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "name"
     t.datetime "created_at"
+    t.string "name"
     t.datetime "updated_at"
   end
 end


### PR DESCRIPTION
It was noticed in #14 that the support for polymorphic relations was incomplete; there were primary key collisions if records of different `friendable_type` but having the same `id` were inserted.

This PR fixes that by introducing a new DB migration that redoes the unique index on the `friendships` table, so that the `friendable_type` column is included in the index. Tests also added.